### PR TITLE
Don't make deep copy when convert from data.frame to data.table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 *.zip
 *.Rproj
 *.dll
+*.so

--- a/R/fst.R
+++ b/R/fst.R
@@ -124,7 +124,7 @@ read.fst <- function(path, columns = NULL, from = 1, to = NULL, as.data.table = 
   if (as.data.table)
   {
     keyNames <- res$keyNames
-    res <- as.data.table(res$resTable)
+    res <- data.table::setDT(res$resTable)
     attr(res, "sorted") <- keyNames
     return(res)
   }


### PR DESCRIPTION
Minor improvement, but in my benchmarks it saves ~10% of runtime. Issue is that `as.data.table` makes deep copy of input data.frame while `setDT` converts it in place.