### PR TITLE
Use data.table::setattr instead of attr<- when reading keyed data.table

### DIFF
--- a/R/fst.R
+++ b/R/fst.R
@@ -193,7 +193,7 @@ read_fst <- function(path, columns = NULL, from = 1, to = NULL, as.data.table = 
 
     keyNames <- res$keyNames
     res <- data.table::setDT(res$resTable)  # nolint
-    if (length(keyNames) > 0 ) attr(res, "sorted") <- keyNames
+    if (length(keyNames) > 0 ) data.table::setattr(res, "sorted", keyNames)
     return(res)
   }
 


### PR DESCRIPTION
This avoids a data.table warning message and shallow copy of the table upon modification of its columns by reference. I tested this with the latest CRAN version of data.table (1.10.4.3). Here's a repro:

```
x <- data.table::data.table(a = 1, key = 'a')
fst::write_fst(x, '/tmp/x.fst')
xx <- fst::read_fst('/tmp/x.fst', as.data.table = TRUE)
xx[, b := 1]
```
Note: I took CONTRIBUTING.md literally and added myself to the authors@R list. However, this contribution feels so minor and the list so short that I do not mind being omitted -- unsure of usual practice.