### PR TITLE
 Allow fst.threads option to set number of threads

### DIFF
--- a/R/onAttach.R
+++ b/R/onAttach.R
@@ -48,13 +48,16 @@
     # Check for OpenMP support
     if (!hasopenmp()) {
       packageStartupMessage("(OpenMP was not detected, using single threaded mode)")
+    } else if (!is.null(getOption("fst.threads"))) {
+      packageStartupMessage("(OpenMP detected, setting to ", threads_fst(),
+        " cores from option fst.threads)")
     } else {
       physical_cores <- parallel::detectCores(logical = FALSE)
-      logical_cores <- parallel::detectCores(logical = TRUE)
+      physical_cores <- ifelse(is.na(physical_cores), 1L, physical_cores)
 
-      # The default number of cores is set to the number of logical cores available on the system.
-      # Benchmarks show that hyperthreading increases the read- and write performance of fst.
-      threads_fst(logical_cores)
+      logical_cores <- parallel::detectCores(logical = TRUE)
+      logical_cores <- ifelse(is.na(logical_cores), 1L, logical_cores)
+
 
       packageStartupMessage("(OpenMP detected, using ", threads_fst(),
         if (physical_cores != logical_cores) " logical", " cores)")

--- a/R/openmp.R
+++ b/R/openmp.R
@@ -30,6 +30,11 @@
 #' specific requirements. As a default, \code{fst} uses a number of threads equal to the number of
 #' logical cores in the system.
 #'
+#' The number of threads can also be set with \code{option(fst.threads = N)}.
+#' NOTE: This option is only read when the package's namespace is first loaded, with commands like
+#' \code{library}, \code{require}, or \code{::}. If you have already used one of these, you
+#' must use \code{threads_fst} to set the number of threads.
+#'
 #' @param nr_of_threads number of threads to use or \code{NULL} to get the current number of threads used in
 #' multithreaded operations.
 #'

--- a/R/package.R
+++ b/R/package.R
@@ -115,6 +115,23 @@ NULL
 #' @aliases fst-package
 NULL
 
+.onLoad <- function(libname, pkgname) {
+  # Set the number of threads here. .onAttach will read threads_fst() and display a
+  # useful startup message.
+  if (is.null(getOption("fst.threads"))) {
+    logical_cores <- parallel::detectCores(logical = TRUE)
+    # If R can't figure out how many logical cores, ask OpenMP to use all
+    logical_cores <- ifelse(is.na(logical_cores), 0L, logical_cores)
+
+    # The default number of cores is set to the number of logical cores available on the system.
+    # Benchmarks show that hyperthreading increases the read- and write performance of fst.
+    threads_fst(logical_cores)
+  } else {
+    # Don't need to validate here; threads_fst checks its input
+    threads_fst(getOption("fst.threads"))
+  }
+}
+
 
 .onUnload <- function (libpath) {
   library.dynam.unload("fst", libpath)

--- a/man/threads_fst.Rd
+++ b/man/threads_fst.Rd
@@ -22,3 +22,9 @@ fastest solution. With \code{threads_fst} the number of threads can be adjusted 
 specific requirements. As a default, \code{fst} uses a number of threads equal to the number of
 logical cores in the system.
 }
+\details{
+The number of threads can also be set with \code{option(fst.threads = N)}.
+NOTE: This option is only read when the package's namespace is first loaded, with commands like
+\code{library}, \code{require}, or \code{::}. If you have already used one of these, you
+must use \code{threads_fst} to set the number of threads.
+}

--- a/tests/testthat/test_omp.R
+++ b/tests/testthat/test_omp.R
@@ -33,25 +33,21 @@ test_that("threads_fst(0) use all logical cores", {
 })
 
 test_that("Loading fst works with options", {
-  skip("Currently causes a segfault")
+
   # Note that neither of the tests in this block will be informative when run
   # on a machine without openmp. They'll pass even if the thing they're testing
   # is broken.
 
-  # I'm not sure how to get testthat to test the effects of .onLoad and
-  # .onAttach. Here was my attempt, but the code below causes a segfault.
-
-  unloadNamespace("fst")
   orig_op <- getOption("fst.threads")
   options(fst.threads = 1)
   # First test that .onload, which happens when the namespace is loaded by ::,
   # reads from the fst.threads option.
-  loadNamespace("fst")
-  nrOfThreads <- fst::threads_fst()
+  fst:::.onLoad()
+  nrOfThreads <- threads_fst()
   expect_equal(nrOfThreads, 1)
   # Next, test that using attaching the package doesn't change
   # the number of threads.
-  attachNamespace("fst")
+  fst:::.onAttach()
   nrOfThreads <- threads_fst()
   expect_equal(nrOfThreads, 1)
   options(fst.threads = orig_op)  # reset option

--- a/tests/testthat/test_omp.R
+++ b/tests/testthat/test_omp.R
@@ -29,7 +29,13 @@ test_that("threads_fst(0) use all logical cores", {
   threads_fst(0)
   nrOfThreads <- threads_fst()
   logical_cores <- parallel::detectCores(logical = TRUE)
-  expect_equal(nrOfThreads, logical_cores)
+
+  # Systems with OpenMP activated should have more than a single thread
+  if (fst:::hasopenmp()) {
+    expect_equal(nrOfThreads, logical_cores)
+  } else {
+    expect_equal(nrOfThreads, 1)
+  }
 })
 
 test_that("Loading fst works with options", {

--- a/tests/testthat/test_omp.R
+++ b/tests/testthat/test_omp.R
@@ -24,3 +24,35 @@ test_that("Get number of threads", {
     expect_equal(nrOfThreads, 1)
   }
 })
+
+test_that("threads_fst(0) use all logical cores", {
+  threads_fst(0)
+  nrOfThreads <- threads_fst()
+  logical_cores <- parallel::detectCores(logical = TRUE)
+  expect_equal(nrOfThreads, logical_cores)
+})
+
+test_that("Loading fst works with options", {
+  skip("Currently causes a segfault")
+  # Note that neither of the tests in this block will be informative when run
+  # on a machine without openmp. They'll pass even if the thing they're testing
+  # is broken.
+
+  # I'm not sure how to get testthat to test the effects of .onLoad and
+  # .onAttach. Here was my attempt, but the code below causes a segfault.
+
+  unloadNamespace("fst")
+  orig_op <- getOption("fst.threads")
+  options(fst.threads = 1)
+  # First test that .onload, which happens when the namespace is loaded by ::,
+  # reads from the fst.threads option.
+  loadNamespace("fst")
+  nrOfThreads <- fst::threads_fst()
+  expect_equal(nrOfThreads, 1)
+  # Next, test that using attaching the package doesn't change
+  # the number of threads.
+  attachNamespace("fst")
+  nrOfThreads <- threads_fst()
+  expect_equal(nrOfThreads, 1)
+  options(fst.threads = orig_op)  # reset option
+})


### PR DESCRIPTION
- Read from `fst.threads` option in `.onLoad`
- Move `thread_fst` from `.onAttach` to `.onLoad`
- Check that `parallel::detectCores` doesn't return `NA`
- Add tests

I didn't ask if you liked the name `fst.threads`.  I'm happy to go with something else if it would be better.

Fixes #132