### PR TITLE
Return invisible result from setnrofthreads

### DIFF
--- a/R/openmp.R
+++ b/R/openmp.R
@@ -62,5 +62,5 @@ threads_fst <- function(nr_of_threads = NULL, reset_after_fork = NULL) {
     return(getnrofthreads())
   }
 
-  setnrofthreads(nr_of_threads)
+  invisible(setnrofthreads(nr_of_threads))
 }


### PR DESCRIPTION
I think it makes more sense to return invisible number of threads previously used when calling `threads_fst` so that setting the number of threads does not explicitly print anything in `Rscript`. `data.table::setDTthreads(n)` adopts such behavior.
