### PR TITLE
Bug fix for 0-row tables

### DIFF
--- a/R/fst_table.R
+++ b/R/fst_table.R
@@ -262,7 +262,7 @@ print.fst_table <- function(x, number_of_rows = 50, ...) {
       type_row,
       sample_data_print)
 
-    rownames(sample_data_print) <- c(" ", 1:meta_info$nrOfRows)
+    rownames(sample_data_print) <- c(" ", seq_len(meta_info$nrOfRows))
 
     # no color terminal available
     if (!color_on) {


### PR DESCRIPTION
Fixes the error below if there is a 0-row fst table being called. c.f. [#99 ](https://github.com/fstpackage/fst/issues/99)

```R
library(fst)
# create a 0-row data frame
noRows = data.frame(aa=numeric(0), bb=character(0), cc=logical(0))
fst::write_fst(noRows, "noRowsFstFile.fst")
fst::read_fst("noRowsFstFile.fst")# works fine
fst::fst("noRowsFstFile.fst")
# the above gives error: Error in `.rowNamesDF<-`(x, value = value) : invalid 'row.names' length
```