### PR TITLE
DESCRIPTION: drop misleading requirement for little-endian

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,6 @@ Imports:
 LinkingTo:
     Rcpp,
     fstcore
-SystemRequirements: little-endian platform
 RoxygenNote: 7.2.3
 Suggests:
     testthat,


### PR DESCRIPTION
Closes: https://github.com/fstpackage/fst/issues/275

`fstcore` and `fst` build and pass all tests on Big-endian arch. Misleading requirement for LE should be dropped.

Tested on PPC G5 (natively) and in Rosetta, everything works.