### PR TITLE
check column availability before reading

### DIFF
--- a/R/fst.R
+++ b/R/fst.R
@@ -201,6 +201,16 @@ read_fst <- function(path, columns = NULL, from = 1, to = NULL, as.data.table = 
     if (!is.character(columns)) {
       stop("Parameter 'columns' should be a character vector of column names.")
     }
+
+    # check if any requested 'columns' are not present in the 'path'
+    file_cols = metadata_fst(path)$columnNames
+    miss_cols = setdiff(columns, file_cols)
+
+    if (length(miss_cols) > 0) {
+      stop("Parameter 'columns' should name columns in the file stored at 'path'. These columns are not in that file: ",
+           paste(miss_cols, collapse = ", "))
+    }
+
   }
 
   if (!is.numeric(from) || from < 1 || length(from) != 1) {


### PR DESCRIPTION
I've really enjoyed using `fst` — the read/write and compression are wonderful. Sometimes I  create problems for myself when I try to read a column that doesn't exist in a dataset. For example:
```
library(fst)
test_df = data.frame(a = 1)
write_fst(test_df, 'test.fst')
read_fst('test.fst', columns='b')
```

produces the error:
```
 *** caught bus error ***
address 0x0, cause 'invalid alignment'

Traceback:
 1: fstretrieve(file_name, columns, from, to)
 2: read_fst("test.fst", columns = "b")

Possible actions:
1: abort (with core dump, if enabled)
2: normal R exit
3: exit R without saving workspace
4: exit R saving workspace
```

I'm running `fst` version 0.9.8 and `fstcore` version 0.9.18.

I'm proposing a fix that checks the requested `columns` against those found by `metadata_fst()`, and throws an error if the user requests a column not present in the file.

Apologies if this is already in the works! I did a quick scan of open issues but didn't see something like this.